### PR TITLE
Fix path images migrations

### DIFF
--- a/Core/FieldHandler/IbexaBinaryFile.php
+++ b/Core/FieldHandler/IbexaBinaryFile.php
@@ -8,7 +8,7 @@ use Kaliop\IbexaMigrationBundle\API\FieldValueConverterInterface;
 class IbexaBinaryFile extends FileFieldHandler implements FieldValueConverterInterface
 {
     /**
-     * @param array|string $fieldValue The path to the file or an array with 'path' key
+     * @param array|string $fieldValue The path to the file or an array with 'input_uri' key
      * @param array $context The context for execution of the current migrations. Contains f.e. the path to the migration
      * @return BinaryFileValue
      *
@@ -24,7 +24,7 @@ class IbexaBinaryFile extends FileFieldHandler implements FieldValueConverterInt
         } if (is_string($fieldValue)) {
             $filePath = $fieldValue;
         } else {
-            $filePath = $this->referenceResolver->resolveReference($fieldValue['path']);
+            $filePath = $this->referenceResolver->resolveReference($fieldValue['input_uri']);
             if (isset($fieldValue['filename'])) {
                 $fileName = $this->referenceResolver->resolveReference($fieldValue['filename']);
             }
@@ -43,7 +43,7 @@ class IbexaBinaryFile extends FileFieldHandler implements FieldValueConverterInt
         }
 
         $fieldValues = array(
-            'path' => $realFilePath,
+            'inputUri' => $realFilePath,
             'fileSize' => filesize($realFilePath),
             'fileName' => $fileName != '' ? $fileName : basename($realFilePath),
             //'mimeType' => $mimeType != '' ? $mimeType : mime_content_type($realFilePath)
@@ -73,7 +73,7 @@ class IbexaBinaryFile extends FileFieldHandler implements FieldValueConverterInt
         $binaryFile = $this->ioService->loadBinaryFile($fieldValue->id);
         /// @todo we should handle clustered configurations, to give back the absolute path on disk rather than the 'virtual' one
         return array(
-            'path' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($binaryFile->uri) : $binaryFile->uri),
+            'inputUri' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($binaryFile->uri) : $binaryFile->uri),
             'filename'=> $fieldValue->fileName,
             'mimeType' => $fieldValue->mimeType
         );

--- a/Core/FieldHandler/IbexaImage.php
+++ b/Core/FieldHandler/IbexaImage.php
@@ -10,7 +10,7 @@ class IbexaImage extends FileFieldHandler implements FieldValueConverterInterfac
     /**
      * Creates a value object to use as the field value when setting an image field type.
      *
-     * @param array|string $fieldValue The path to the file or an array with 'path' and 'alt_text' keys
+     * @param array|string $fieldValue The path to the file or an array with 'input_uri' and 'alt_text' keys
      * @param array $context The context for execution of the current migrations. Contains f.e. the path to the migration
      * @return ImageValue
      *
@@ -26,7 +26,7 @@ class IbexaImage extends FileFieldHandler implements FieldValueConverterInterfac
         } else if (is_string($fieldValue)) {
             $filePath = $fieldValue;
         } else {
-            $filePath = $this->referenceResolver->resolveReference($fieldValue['path']);
+            $filePath = $this->referenceResolver->resolveReference($fieldValue['input_uri']);
             if (isset($fieldValue['alt_text'])) {
                 $altText = $this->referenceResolver->resolveReference($fieldValue['alt_text']);
             }
@@ -46,7 +46,7 @@ class IbexaImage extends FileFieldHandler implements FieldValueConverterInterfac
 
         return new ImageValue(
             array(
-                'path' => $realFilePath,
+                'inputUri' => $realFilePath,
                 'fileSize' => filesize($realFilePath),
                 'fileName' => $fileName != '' ? $fileName : basename($realFilePath),
                 'alternativeText' => $altText
@@ -69,7 +69,7 @@ class IbexaImage extends FileFieldHandler implements FieldValueConverterInterfac
 
         /// @todo we should handle clustered configurations, to give back the absolute path on disk rather than the 'virtual' one
         return array(
-            'path' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($fieldValue->uri) : $fieldValue->uri),
+            'input_uri' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($fieldValue->uri) : $fieldValue->uri),
             'filename'=> $fieldValue->fileName,
             'alternativeText' => $fieldValue->alternativeText
         );

--- a/Core/FieldHandler/IbexaMedia.php
+++ b/Core/FieldHandler/IbexaMedia.php
@@ -10,7 +10,7 @@ class IbexaMedia extends FileFieldHandler implements FieldValueConverterInterfac
     /**
      * Creates a value object to use as the field value when setting a media field type.
      *
-     * @param array|string $fieldValue The path to the file or an array with 'path' and many other keys
+     * @param array|string $fieldValue The path to the file or an array with 'input_uri' and many other keys
      * @param array $context The context for execution of the current migrations. Contains f.e. the path to the migration
      * @return MediaValue
      *
@@ -31,7 +31,7 @@ class IbexaMedia extends FileFieldHandler implements FieldValueConverterInterfac
         } else if (is_string($fieldValue)) {
             $filePath = $fieldValue;
         } else {
-            $filePath = $fieldValue['path'];
+            $filePath = $fieldValue['input_uri'];
             if (isset($fieldValue['filename'])) {
                 $fileName = $this->referenceResolver->resolveReference($fieldValue['filename']);
             }
@@ -66,7 +66,7 @@ class IbexaMedia extends FileFieldHandler implements FieldValueConverterInterfac
 
         return new MediaValue(
             array(
-                'path' => $realFilePath,
+                'inputUri' => $realFilePath,
                 'fileSize' => filesize($realFilePath),
                 'fileName' => $fileName != '' ? $fileName : basename($realFilePath),
                 'mimeType' => $mimeType != '' ? $mimeType : mime_content_type($realFilePath),
@@ -92,7 +92,7 @@ class IbexaMedia extends FileFieldHandler implements FieldValueConverterInterfac
         $binaryFile = $this->ioService->loadBinaryFile($fieldValue->id);
         /// @todo we should handle clustered configurations, to give back the absolute path on disk rather than the 'virtual' one
         return array(
-            'path' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($binaryFile->uri) : $fieldValue->uri),
+            'input_uri' => realpath($this->ioRootDir) . '/' . ($this->ioDecorator ? $this->ioDecorator->undecorate($binaryFile->uri) : $fieldValue->uri),
             'filename'=> $fieldValue->fileName,
             'mime_type' => $fieldValue->mimeType,
             'has_controller' => $fieldValue->hasController,


### PR DESCRIPTION
Due to the changes in image management for ibexa5, the migrations of images were broken.
 I did a minimalist fix in order to the IbexaImage FieldHandler to use the new propriety name of the path of an image.