### PR TITLE
fix: add match_tolerate_misses support to ObjectStateGroupMatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /vendor
 /vendor_*
 /Tests/dsl/good/references/test_refs_generated.yml
+
+**/.DS_Store

--- a/Core/Matcher/ObjectStateGroupMatcher.php
+++ b/Core/Matcher/ObjectStateGroupMatcher.php
@@ -33,7 +33,7 @@ class ObjectStateGroupMatcher extends RepositoryMatcher implements KeyMatcherInt
      */
     public function match(array $conditions, $tolerateMisses = false)
     {
-        return $this->matchObjectStateGroup($conditions);
+        return $this->matchObjectStateGroup($conditions, $tolerateMisses);
     }
 
     protected function getConditionsFromKey($key)


### PR DESCRIPTION
This PR fixes missing `match_tolerate_misses` handling for ObjectStateGroupMatcher.

With match_tolerate_misses: true, missing matches no longer fail execution of idempotent migrations
Default behavior remains unchanged.