### PR TITLE
Add ibexa_landing_page field handler to allow industrial processes

### DIFF
--- a/Core/FieldHandler/IbexaLandingPage.php
+++ b/Core/FieldHandler/IbexaLandingPage.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Kaliop\IbexaMigrationBundle\Core\FieldHandler;
+
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Ibexa\FieldTypePage\FieldType\LandingPage\Type;
+use Ibexa\FieldTypePage\FieldType\LandingPage\Value;
+use Ibexa\FieldTypePage\FieldType\Page\Block\Definition\BlockDefinitionFactory;
+use Kaliop\IbexaMigrationBundle\API\FieldValueConverterInterface;
+
+class IbexaLandingPage extends AbstractFieldHandler implements FieldValueConverterInterface
+{
+    public function __construct(
+        private readonly ?BlockDefinitionFactory $blockDefinitionFactory,
+        private readonly ?Type $type,
+        private readonly ?ContentService $contentService,
+    )
+    {
+    }
+
+    /**
+     * Converts the Content Field value as gotten from the repo into something that can generate a re-usable migration definition into something the repo can understand
+     *
+     * @param mixed $fieldValue The Content Field value hash as gotten from the repo
+     * @param array $context    The context for execution of the current migrations. Contains f.e. the path to the migration
+     * @return array<string, mixed> the array as a field value in a migration definition
+     * @throws InvalidArgumentException
+     */
+    public function fieldValueToHash($fieldValue, array $context = array()): array
+    {
+        if (!$this->blockDefinitionFactory || !$this->type || !$this->contentService) {
+            throw new \DomainException('Missing required dependencies for ibexa_landing_page field handler');
+        }
+        if (!$fieldValue instanceof Value) {
+            throw new \DomainException('Bad value type');
+        }
+
+        return $this->getFieldHashWithEmbedValueModified(
+            $this->type->toHash($fieldValue),
+            $this->replaceContentIdByRemoteId(...)
+        );
+    }
+
+    /**
+     * Converts the Content Field value as gotten from the migration definition into something the repo can understand
+     *
+     * @param mixed $fieldHash The Content Field value hash as gotten from the migration definition
+     * @param array $context The context for execution of the current migrations. Contains f.e. the path to the migration
+     * @return mixed the obj usable as field value in a Content create/update struct
+     */
+    public function hashToFieldValue($fieldHash, array $context = array()): Value
+    {
+        if (!$this->blockDefinitionFactory || !$this->type || !$this->contentService) {
+            throw new \DomainException('Missing required dependencies for ibexa_landing_page field handler');
+        }
+
+        if (!$fieldHash) {
+            return $this->type->fromHash(null);
+        }
+
+        if (!is_array($fieldHash)) {
+            throw new \DomainException('Bad value type');
+        }
+
+        return $this->type->fromHash($this->getFieldHashWithEmbedValueModified($fieldHash, $this->replacePotentialRemoteIdByContentId(...)));
+    }
+
+    /**
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     */
+    private function replaceContentIdByRemoteId(?int $value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+        return $this->contentService->loadContentInfo($value)->remoteId;
+    }
+
+    /**
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     */
+    private function replacePotentialRemoteIdByContentId(string|int|null $value): ?int
+    {
+        if (!$value) {
+            return null;
+        }
+        if (is_int($value)) {
+            return $value;
+        }
+        return $this->contentService->loadContentInfoByRemoteId($value)->id;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getFieldHashWithEmbedValueModified(array $fieldHash, mixed $callback): array
+    {
+        $embedAttributesByBlockIdentifier = $this->getEmbedAttributesByBlockIdentifier();
+
+        $blockIdentifiersToHandle = array_keys($embedAttributesByBlockIdentifier);
+
+        if (!isset($fieldHash['zones'])) {
+            return $fieldHash;
+        }
+
+        foreach($fieldHash['zones'] as &$zoneInfo) {
+            if (!isset($zoneInfo['blocks'])) {
+                continue;
+            }
+            foreach ($zoneInfo['blocks'] as &$blockInfo) {
+                if (!in_array($blockInfo['type'] ?? null, $blockIdentifiersToHandle, true)) {
+                    continue;
+                }
+
+                $attributeNameToHandle = $embedAttributesByBlockIdentifier[$blockInfo['type']];
+                foreach ($blockInfo['attributes'] as &$attribute) {
+                    if (in_array($attribute['name'] ?? null, $attributeNameToHandle, true)) {
+                        $attribute['value'] = $callback($attribute['value']);
+                    }
+                }
+            }
+        }
+
+        return $fieldHash;
+    }
+
+    private function getEmbedAttributesByBlockIdentifier(): array
+    {
+        static $embedAttributesByBlockIdentifier = null;
+        if ($embedAttributesByBlockIdentifier !== null) {
+            return $embedAttributesByBlockIdentifier;
+        }
+
+        $embedAttributesByBlockIdentifier = [];
+
+        $blockDefinition = $this->blockDefinitionFactory->getConfiguration();
+        foreach ($blockDefinition as $blockIdentifier => $config) {
+            foreach ($config['attributes'] ?? [] as $attributeIdentifier => $attributeInfo) {
+                if ($attributeInfo['type'] === 'embed') {
+                    if (!isset($embedAttributesByBlockIdentifier[$blockIdentifier])) {
+                        $embedAttributesByBlockIdentifier[$blockIdentifier] = [];
+                    }
+                    $embedAttributesByBlockIdentifier[$blockIdentifier][] = $attributeIdentifier;
+                }
+            }
+        }
+
+        return $embedAttributesByBlockIdentifier;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -112,6 +112,7 @@ parameters:
     kaliop_migration_bundle.complex_field.ibexa_image.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaImage
     kaliop_migration_bundle.complex_field.ibexa_matrix.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaMatrix
     kaliop_migration_bundle.complex_field.ibexa_media.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaMedia
+    kaliop_migration_bundle.complex_field.ibexa_landing_page.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaLandingPage
     #kaliop_migration_bundle.complex_field.ezpage.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\EzPage
     kaliop_migration_bundle.complex_field.ezrelation.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaRelation
     kaliop_migration_bundle.complex_field.ezrelationlist.class: Kaliop\IbexaMigrationBundle\Core\FieldHandler\IbexaRelationList
@@ -729,6 +730,16 @@ services:
             - "@?ibexa.field_type.ibexa_binaryfile.io_service"
         tags:
             - { name: kaliop_migration_bundle.complex_field, fieldtype: ibexa_media, priority: 0 }
+
+    kaliop_migration_bundle.complex_field.ibexa_landing_page:
+        parent: kaliop_migration_bundle.complex_field
+        class: '%kaliop_migration_bundle.complex_field.ibexa_landing_page.class%'
+        arguments:
+            - "@?Ibexa\\FieldTypePage\\FieldType\\Page\\Block\\Definition\\BlockDefinitionFactory"
+            - "@?Ibexa\\FieldTypePage\\FieldType\\LandingPage\\Type"
+            - "@?Ibexa\\Contracts\\Core\\Repository\\ContentService"
+        tags:
+            - { name: kaliop_migration_bundle.complex_field, fieldtype: ibexa_landing_page, priority: 0 }
 
     #kaliop_migration_bundle.complex_field.ezpage:
     #    lazy: true

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -738,6 +738,7 @@ services:
             - "@?Ibexa\\FieldTypePage\\FieldType\\Page\\Block\\Definition\\BlockDefinitionFactory"
             - "@?Ibexa\\FieldTypePage\\FieldType\\LandingPage\\Type"
             - "@?Ibexa\\Contracts\\Core\\Repository\\ContentService"
+            - "@?Ibexa\\Contracts\\Core\\Repository\\LocationService"
         tags:
             - { name: kaliop_migration_bundle.complex_field, fieldtype: ibexa_landing_page, priority: 0 }
 

--- a/Resources/doc/DSL/Contents.yml
+++ b/Resources/doc/DSL/Contents.yml
@@ -77,6 +77,9 @@
         attribute18: # nb: the keys must match column identifiers
             - { authors: 'Author A, Author B', title: 'Lorem ipsum', release_info: '2012' }
             - { authors: 'Author 1, Author 2', title: 'Lorem ipsum dolor sit amet', release_info: 'R info abc' }
+        # ibexa_landing_page (Ibexa Experience and  above)
+        attribute19: # nb: When a string is used as an embed block value, it is assumed to be a content remote id
+            - { id: '41', name: default, blocks: [{ visible: true, id: '42', type: text_cta, name: 'Text / CTA', view: default, class: null, style: null, compiled: '', since: null, till: null, attributes: [{ id: '43', name: title, value: 'Test' }, { id: '44', name: cta, value: 'my_cta' }] }] }
     always_available: true|false # Optional, will default to content type defaultAlwaysAvailable
     is_hidden: true|false # Optional
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)


### PR DESCRIPTION
Handle remote ids, the same way its handled for `ibexa_object_relation` type, but in the following landing page type, even nested : 
- embed
- locationList
- richtext (only for ezcontent:// link)

Traditional ids still works, but migration generation using `kaliop:migartion:generate` uses remote ids.